### PR TITLE
If no arguments specified use stdin and stdout.

### DIFF
--- a/core/cli.h
+++ b/core/cli.h
@@ -7,7 +7,7 @@
     {                                           \
         fprintf(stderr, "\n" MESSAGE "\n", __VA_ARGS__ );\
         exit( CODE );                           \
-    } 
+    }
 
 
 #define PRINT_OPTION_INFO( OPTION_TEXT , OPTION_DESCRIPTION ) \
@@ -40,11 +40,8 @@ void usage_info(int argc, char **argv)
 void read_cli_options(int argc, char **argv)
 {
     int i;
-    if(argc == 1)
-    {
-      usage_info(argc, argv);
-      exit(0);
-    }
+    if(argc == 1) return; // use stdin and stdout
+
     for(i=1;i<argc;i++)
     {
         if( argv[i][0] != '-')


### PR DESCRIPTION
Hi, I wanted to use fsqlf from emacs `shell-command-on-region`, however if no arguments are specified it prints usage info and exits. Changed to use stdin/stdout if no args are specified. You might want to make this smarter. e.g. support `fsqlf - output_file` which would read from `stdin` and write to `output_file`.
